### PR TITLE
FIX: start button now starts at the value in input field

### DIFF
--- a/aion/lib/main.dart
+++ b/aion/lib/main.dart
@@ -214,6 +214,7 @@ class _SetTimerState extends State<SetTimer> {
   }
 
   void start_timer() {
+    timer_reset();
     timer = Timer.periodic(second_duration, (timer) => { add_time() });
     setState(() {
       setup = false;


### PR DESCRIPTION
Start button will start at value entered
fixes 
https://github.com/deaf-glassmakers/Aion/issues/4